### PR TITLE
Fix Bug #721: [NetworkBrowser] Wrong mount/unmount logic for enigma2 …

### DIFF
--- a/networkbrowser/src/AutoMount.py
+++ b/networkbrowser/src/AutoMount.py
@@ -307,14 +307,12 @@ class AutoMount():
 						tmpdir = tmpsharedir.replace("$", "\\$")
 						tmpsharedir = tmpdir
 					if data['mounttype'] == 'nfs':
-						if not os.path.ismount(path):
-							tmpcmd = 'mount -t nfs -o ' + self.sanitizeOptions(data['options']) + ' ' + data['ip'] + ':/' + tmpsharedir + ' ' + path
-							mountcommand = tmpcmd.encode("UTF-8")
+						tmpcmd = 'mount -t nfs -o ' + self.sanitizeOptions(data['options']) + ' ' + data['ip'] + ':/' + tmpsharedir + ' ' + path
+						mountcommand = tmpcmd.encode("UTF-8")
 					elif data['mounttype'] == 'cifs':
-						if not os.path.ismount(path):
-							tmpusername = data['username'].replace(" ", "\\ ")
-							tmpcmd = 'mount -t cifs -o ' + self.sanitizeOptions(data['options'], cifs=True) +',noatime,noserverino,username='+ tmpusername + ',password='+ data['password'] + ' //' + data['ip'] + '/' + tmpsharedir + ' ' + path
-							mountcommand = tmpcmd.encode("UTF-8")
+						tmpusername = data['username'].replace(" ", "\\ ")
+						tmpcmd = 'mount -t cifs -o ' + self.sanitizeOptions(data['options'], cifs=True) +',noatime,noserverino,username='+ tmpusername + ',password='+ data['password'] + ' //' + data['ip'] + '/' + tmpsharedir + ' ' + path
+						mountcommand = tmpcmd.encode("UTF-8")
 
 		for x in unmountcommand:
 			command.append(x)


### PR DESCRIPTION
…mounts

Iin AutoMount.doCheckMountPoint(), remove the

if not os.path.ismount(path)

tests for mounts using enigma2 or old_enigma2.

There are still potential problems if the unmounts fail (e.g. the
mounted devices are busy), and Console.eBatch() doesn't provide ant
feedback about any filures of the commands it runs, so warnings
can't be issued.