### PR TITLE
 Fix Bug #719: [NetworkBrowser] "Enigma2 old format" mounts can fail 

### DIFF
--- a/networkbrowser/src/AutoMount.py
+++ b/networkbrowser/src/AutoMount.py
@@ -89,28 +89,18 @@ class AutoMount():
 		tree = cet_parse(file).getroot()
 		file.close()
 
-		mountusing = 0 # 0=old_enigma2, 1 =fstab, 2=enigma2
 		# Config is stored in "mountmanager" element
-		mountusing_values = {
-			"autofs": 1,
-			"fstab": 2,
-			"enigma2": 3,
-			"old_enigma2": 0,
-		}
-		for mntusing in ("autofs", "fstab", "enigma2"):
-			for mountusingnode in tree.findall(mntusing):
-				mountusing = mountusing_values[mntusing]
-
+		for mountusing in ("autofs", "fstab", "enigma2"):
+			for mountusingnode in tree.findall(mountusing):
 				for mounttype in ("nfs", "cifs"):
 					for fs in mountusingnode.findall(mounttype):
 						for mount in fs.findall("mount"):
-							self.makeAutoMountPoint(mntusing, mounttype, mount)
+							self.makeAutoMountPoint(mountusing, mounttype, mount)
 
-		if mountusing == 0:
-			for mounttype in ("nfs", "cifs"):
-				for fs in tree.findall(mounttype):
-					for mount in fs.findall("mount"):
-						self.makeAutoMountPoint("old_enigma2", mounttype, mount)
+		for mounttype in ("nfs", "cifs"):
+			for fs in tree.findall(mounttype):
+				for mount in fs.findall("mount"):
+					self.makeAutoMountPoint("old_enigma2", mounttype, mount)
 
 		self.checkList = self.automounts.keys()
 		if not self.checkList:

--- a/networkbrowser/src/MountEdit.py
+++ b/networkbrowser/src/MountEdit.py
@@ -127,7 +127,6 @@ class AutoMountEdit(Screen, ConfigListScreen):
 		self.mountusing.append(("autofs", _("AUTOFS (mount as needed)")))
 		self.mountusing.append(("fstab", _("FSTAB (mount at boot)")))
 		self.mountusing.append(("enigma2", _("Enigma2 (mount using enigma2)")))
-		self.mountusing.append(("old_enigma2", _("Enigma2 old format (mount using linux)")))
 
 		self.sharetypelist = []
 		self.sharetypelist.append(("cifs", _("CIFS share")))


### PR DESCRIPTION
Refactor AutoMounts.getAutoMountPoints() to remove common code segments that create automount entries to a new method and make differences in the entry fallback for the various parameters clearer.

Remove code that prevented mounts using "old_enigma2" being mounted if any other "mount using" types are used.

Convert mounts using "old_enigma2" to "enigma2" and remove all references to mounts using "old_enigma2" in the remaining code.